### PR TITLE
Add height and width values and functions to the term module and get rid off double `#!./buildfiles/et` in `tests/mem_funcs.et`

### DIFF
--- a/include/ethereal/term.et
+++ b/include/ethereal/term.et
@@ -1,1 +1,8 @@
 ldmod term;
+
+struct _term_t {
+	width = term_width();
+	height = term_height();
+}
+
+term = _term_t{};

--- a/tests/mem_funcs.et
+++ b/tests/mem_funcs.et
@@ -1,7 +1,5 @@
 #!./buildfiles/et
 
-#!./buildfiles/et
-
 import str;
 
 mfn< int > add_one() {

--- a/tests/mod_term.et
+++ b/tests/mod_term.et
@@ -7,3 +7,6 @@ println( colorize( '{r}red{0}' ) );
 cprint( '{r}red{0}' );
 
 cprintln( '{r}red{0}' );
+
+println( 'width: ', term.width.to_str() );
+println( 'height: ', term.height.to_str() );


### PR DESCRIPTION
Also adds tests to the term test script.